### PR TITLE
Declutter timestamp representation

### DIFF
--- a/purpler/bot.py
+++ b/purpler/bot.py
@@ -188,7 +188,7 @@ class PurplerBot(auth.SASL, conn.SSL, bot.SingleServerIRCBot):
                         out_nick, the_message = outgoing_message.content.split(':', 1)
                         msg = '<%s> %s [%s] [n %s]' % (
                             out_nick.strip(), the_message.strip(),
-                            outgoing_message.when,
+                            f'{outgoing_message.when:%Y-%m-%d %H:%M}',
                             outgoing_message.guid)
                     c.privmsg(e.target, msg)
         self._log(e, message, nick)


### PR DESCRIPTION
> omitting seconds and microseconds

before: 2019-06-04 14:19:49.293948
after: 2019-06-04 14:19

caveat: it looks like there are a few more places where this should be applied; all occurrences of `.when`?